### PR TITLE
Ajoute un fichier "environment.txt" pour Conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,26 @@
+name: UE12
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  # un Python récent
+  - python>=3.10
+  # les deps présentes sur conda-forge
+  - numpy>=2.1
+  - pandas>=2.2
+  - scipy>=1.14
+  - pillow>=10.4
+  - seaborn>=0.13
+  - openpyxl>=3.1
+  - jupyter>=1.0
+  - jupytext>=1.16
+  - jupyterlab-myst>=2.4
+  - ipywidgets>=8.1
+  - ipympl>=0.9
+  - ruamel.yaml>=0.18
+  # Scikit-learn sur conda (!= scikit_learn sur pip !)
+  - scikit-learn>=1.5
+  # Les dépendances pip-only
+  - pip:
+      - jupyterlab-courselevels
+      - ipythontutor


### PR DESCRIPTION
Ce patch ajoute un fichier d'initialisation d'environnement pour conda, afin de pouvoir facilement créer un environnement dédié en une seule commande:

```bash
# Par ex. pour créer un nouvel env nommé "ue12"
$ conda env create -n ue12
```

le nom du fichier à charger (`environment.yml` en l'occurrence) est implicite et on peut ensuite activer très facilement l'environment isolé avec toutes les dépendances et une version récente de Python:

```sh
$ conda activate ue12
```

NOTE: d'après mes tests l'environnement est également bien détecté par VSCode 👍